### PR TITLE
Support non-windows paths

### DIFF
--- a/source/DD4T.DI.Autofac/Bootstrap.cs
+++ b/source/DD4T.DI.Autofac/Bootstrap.cs
@@ -26,7 +26,7 @@ namespace DD4T.DI.Autofac
     {
         public static void UseDD4T(this ContainerBuilder builder)
         {
-            var binDirectory = string.Format(@"{0}\bin\", AppDomain.CurrentDomain.BaseDirectory);
+            var binDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin");
 
             //allowing to register types from any other DD4T.* package into the container:
             //functionality introduced to allow a more plugabble architecture into the framework.

--- a/source/DD4T.DI.Autofac/Mvc.cs
+++ b/source/DD4T.DI.Autofac/Mvc.cs
@@ -10,7 +10,7 @@ namespace DD4T.DI.Autofac
     {
         public static void RegisterMvc(this ContainerBuilder builder)
         {
-            var location = string.Format(@"{0}\bin\", AppDomain.CurrentDomain.BaseDirectory);
+            var location = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin");
             var file = Directory.GetFiles(location, "DD4T.MVC.dll").FirstOrDefault();
             if (file == null)
                 return;


### PR DESCRIPTION
Fix for dd4t under macOS causing System.IO.DirectoryNotFoundException while trying to load /[projectFolder]/\bin\.